### PR TITLE
Documentation fix for how to get RavenRemoteUser

### DIFF
--- a/src/main/java/uk/ac/cam/ucs/webauth/RavenFilter.java
+++ b/src/main/java/uk/ac/cam/ucs/webauth/RavenFilter.java
@@ -94,10 +94,10 @@ import org.apache.commons.logging.LogFactory;
  * 
  * <h3>Retrieve authenticated user name</h3>
  * 
- * Get the value of session or request attribute "RavenRemoteUser".
+ * Get the value of session attribute "RavenRemoteUser".
  * 
  * <p>
- * <code>String userId = request.getAttribute("RavenRemoteUser");</code>
+ * <code>String userId = request.getSession().getAttribute("RavenRemoteUser");</code>
  * </p>
  * 
  * 


### PR DESCRIPTION
request.getAttribute("RavenRemoteUser") always returned null. The RavenRemoteUser
could be extracted from request.getSession().getAttribute("..."), though. The
documentation was adjusted accordingly to state to get the attribute from the session,
not the request.
