### PR TITLE
Allows chaining through filter, and adds 2 init params

### DIFF
--- a/src/main/java/uk/ac/cam/ucs/webauth/RavenFilter.java
+++ b/src/main/java/uk/ac/cam/ucs/webauth/RavenFilter.java
@@ -212,7 +212,7 @@ public class RavenFilter implements Filter {
 	 * Whether the filter allows unauthorised users through, for API filter
 	 * validation
 	 */
-	public static String INIT_PARAM_ALLOW_UNAUTHORISED = "allowedUnauthorised";
+	public static String INIT_PARAM_ALLOW_UNAUTHORISED = "allowUnauthorised";
 	
 	/**
 	 * Override of default max skew - in case there is lag in the clocks


### PR DESCRIPTION
If the allowUnauthorised init param is set to true, allow the request
to pass through the filter, so that it can be validated by a separate
filter.

If the maxSkew init param is set, override the default webauthValidator
maxSkew.
